### PR TITLE
Changed -ErrorAction to "Ignore" to not add error to $Error

### DIFF
--- a/Source/Private/_init.ps1
+++ b/Source/Private/_init.ps1
@@ -12,7 +12,7 @@ if(-not $IsLinux -and -not $IsMacOS) {
     [PoshCode.Pansies.NativeMethods]::EnableVirtualTerminalProcessing()
 }
 
-if(Get-Command Add-MetadataConverter -ErrorAction SilentlyContinue) {
+if(Get-Command Add-MetadataConverter -ErrorAction Ignore) {
     Add-MetadataConverter @{
         RgbColor = { [PoshCode.Pansies.RgbColor]$args[0] }
         [PoshCode.Pansies.RgbColor] = { "RgbColor '$_'" }


### PR DESCRIPTION
When `-ErrorAction` is `SilentlyContinue`, the error is not shown, but is still logged in `$Error` automatic variable and shown from `Get-Error`. By changing it to `Ignore`, the error is not logged.

See following for detailed explanation:
https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_commonparameters?view=powershell-7#erroraction

`Ignore` value was added in PowerShell 3.0, so it should be safe to use for Pansies.